### PR TITLE
Switch from `@Redirect` to `@WrapOperation` in `ChangeActiveSlot` mixin

### DIFF
--- a/src/main/java/me/marzeq/crossbowenhanced/mixins/ChangeActiveSlot.java
+++ b/src/main/java/me/marzeq/crossbowenhanced/mixins/ChangeActiveSlot.java
@@ -1,5 +1,7 @@
 package me.marzeq.crossbowenhanced.mixins;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import me.marzeq.crossbowenhanced.SlotManager;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.player.PlayerInventory;
@@ -7,13 +9,12 @@ import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(MinecraftClient.class)
 public class ChangeActiveSlot {
-    @Redirect(method = {"handleInputEvents", "doItemPick"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;setSelectedSlot(I)V"))
-    private void selectedSlot(PlayerInventory inventory, int i) {
+    @WrapOperation(method = {"handleInputEvents", "doItemPick"}, at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;setSelectedSlot(I)V"))
+    private void selectedSlot(PlayerInventory inventory, int i, Operation<Void> original) {
         if (inventory.getSelectedSlot() == i) return;
 
         if (SlotManager.isSwapped()) {


### PR DESCRIPTION
Prompted by a conflict with a redirect of the same method and target from the mod Axiom. The `@WrapOperation` annotation was used since MixinExtras is recommended by the Fabric Wiki article on mixin redirectors to avoid and fix incompatibilities.

[Mixin Redirectors on Fabric Wiki](https://wiki.fabricmc.net/tutorial:mixin_redirectors)
[WrapOperation on MixinExtras Wiki](https://github.com/LlamaLad7/MixinExtras/wiki/WrapOperation)

I wasn't able to test directly on the development environment because for some reason the OpenGL renderer backend would not spin up, but I compiled the mod and tested it in a Minecraft 1.21.11 instance with Fabric Loader 0.18.4, Fabric API 0.141.3, and Axiom 5.3.0. Both Crossbow Enhanced and Axiom features seemed to be working normally.